### PR TITLE
Update FindSidekiq.cmake to export library dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,6 @@ add_custom_target(uninstall
     ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
     )
 
-# add the epiq directory to the linker directories
-link_directories(
-    "/usr/lib/epiq"
-)
-
 ########################################################################
 # Add subdirectories
 ########################################################################

--- a/cmake/Modules/FindSidekiq.cmake
+++ b/cmake/Modules/FindSidekiq.cmake
@@ -80,8 +80,6 @@ if(NOT Sidekiq_FOUND)
     #    HINTS ${Sidekiq_PKG_LIBRARY_DIRS} $ENV{Sidekiq_DIR}/include
     #    PATHS ~/sidekiq_sw)
 
-    set(Sidekiq_LIBRARIES ${Sidekiq_LIBRARY})
-    set(Sidekiq_INCLUDE_DIRS ${Sidekiq_INCLUDE_DIR})
     set(Sidekiq_PKG_LIBRARY_DIRS "~/sidekiq_sdk_current/lib/support/${SUFFIX}/usr/lib/epiq")
     set(ENV{Sidekiq_DIR} "~/sidekiq_sdk_current")
 
@@ -128,7 +126,7 @@ if(NOT Sidekiq_FOUND)
         message(STATUS "PKG_CONFIG_PATH $ENV{PKG_CONFIG_PATH}")
 
         execute_process(
-            COMMAND pkg-config --libs-only-l grpc++ protobuf
+            COMMAND pkg-config --libs grpc++ protobuf
             OUTPUT_VARIABLE PKG_LIBS
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
@@ -138,15 +136,6 @@ if(NOT Sidekiq_FOUND)
 
         set (PKGCONFIG_LIBS ${PKG_LIBS_LIST} -lgpiod -lstdc++)
         message(STATUS "PKGCONFIG ${PKGCONFIG_LIBS}")
-
-        execute_process(
-            COMMAND pkg-config --variable=libdir protobuf
-            OUTPUT_VARIABLE LIB_PATH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-
-        message(STATUS "LIB_PATH ${LIB_PATH}")
-        link_directories(${LIB_PATH})
 
         include(FindPackageHandleStandardArgs)
         # handle the QUIETLY and REQUIRED arguments and set LibSidekiq_FOUND to TRUE
@@ -170,4 +159,17 @@ if(NOT Sidekiq_FOUND)
         mark_as_advanced(Sidekiq_INCLUDE_DIRS Sidekiq_LIBRARIES OTHER_LIBS PKGCONFIG_LIBS) 
     endif()
 
+    if(Sidekiq_FOUND AND NOT TARGET Sidekiq::sidekiq)
+        add_library(Sidekiq::sidekiq STATIC IMPORTED)
+        set_target_properties(Sidekiq::sidekiq PROPERTIES
+          IMPORTED_LOCATION "${Sidekiq_LIBRARY}"
+          INTERFACE_INCLUDE_DIRECTORIES "${Sidekiq_INCLUDE_DIR}"
+        )
+        target_link_libraries(Sidekiq::sidekiq INTERFACE
+          ${PKGCONFIG_LIBS}
+          ${OTHER_LIBS}
+        )
+    endif()
+    set(Sidekiq_LIBRARIES Sidekiq::sidekiq)
+    set(Sidekiq_INCLUDE_DIRS "${Sidekiq_INCLUDE_DIR}")
 endif(NOT Sidekiq_FOUND)


### PR DESCRIPTION
The Sidekiq Rx Source was failing to run on X40 with
```
Traceback (most recent call last):
  File "/home/sidekiq/waterfall.py", line 23, in <module>
    from gnuradio import sidekiq
  File "/usr/local/lib/python3.8/dist-packages/gnuradio/sidekiq/__init__.py", line 18, in <module>
    from .sidekiq_python import *
ImportError: /usr/local/lib/aarch64-linux-gnu/libgnuradio-sidekiq.so.1.0.0: undefined symbol: _ZTIN6google8protobuf2io20ZeroCopyOutputStreamE
```

Updating the FindSidekiq.cmake to export its dependent libraries/include directories allows libgnuradio-sidekiq.so to properly mark its dependency on libprotobuf and associated libraries and load them at runtime.